### PR TITLE
Logical comparison

### DIFF
--- a/symbols.py
+++ b/symbols.py
@@ -5,5 +5,8 @@ SYMBOL = {
 	'is_leaf': '$',
 	'zero_or_more': '*',
 	'one_or_more': '+',
-	'zero_or_one': '?'
+	'zero_or_one': '?',
+#	'all_children': '[:children:]',
+	'any_child': '[:any_child:]',
+	'all_nodes': '[:all_nodes:]'
 }

--- a/symbols.py
+++ b/symbols.py
@@ -6,7 +6,7 @@ SYMBOL = {
 	'zero_or_more': '*',
 	'one_or_more': '+',
 	'zero_or_one': '?',
-	'all_children': '[:children:]',
+	'children': '[:children:]',
 	'any_child': '[:any_child:]',
 	'all_nodes': '[:all_nodes:]'
 }

--- a/symbols.py
+++ b/symbols.py
@@ -6,7 +6,7 @@ SYMBOL = {
 	'zero_or_more': '*',
 	'one_or_more': '+',
 	'zero_or_one': '?',
-#	'all_children': '[:children:]',
+	'all_children': '[:children:]',
 	'any_child': '[:any_child:]',
 	'all_nodes': '[:all_nodes:]'
 }

--- a/test/test_logical_comparison.py
+++ b/test/test_logical_comparison.py
@@ -6,6 +6,121 @@ import sys
 from ete3 import PhyloTree, Tree, NCBITaxa
 from treematcher import TreePattern
 
+class test_sets_logical_comparison(unittest.TestCase):
+    def setUp(self):
+        if len(sys.argv) > 1 and sys.argv[1]:
+          self.number_of_itteration = int(sys.argv[1])
+        else:
+          self.number_of_itteration = 1000
+
+        if len(sys.argv) > 2 and sys.argv[2]:
+          self.number_of_leaves = int(sys.argv[2])
+        else:
+          self.number_of_leaves = 30
+
+    def logical_comparison_distance(self, treePattern, maxhits=None):
+        # define a tree
+        a = Tree()
+        a.populate(self.number_of_leaves)
+
+        # find the number of nodes
+        length = 0
+        for node in a.traverse():
+            length += 1
+
+        # create a list of defined random distances, so the max can be verified.
+        maximum = 1000.0 # allow a bigger possibility of mistake, by adding a lot of values.
+        dists = []
+        for i in range(0, length):
+            dists += [round(random.uniform(0.1, maximum), 1)]
+
+        # set nodes distances to the nodes
+        cursor = 0
+        for node in a.traverse():
+            node.dist = dists[cursor]
+            cursor += 1
+
+        matched = []
+        not_matched = []
+
+        result = list(treePattern.find_match(a, maxhits=None))
+
+        for node in a.traverse():
+            if node in result:
+                matched += [node]
+            else:
+                not_matched += [node]
+
+        return [matched, not_matched]
+
+
+    def test_less_than_children(self):
+        pattern = TreePattern(""" '@.dist < [:children:].dist' ; """, quoted_node_names=True)
+        test_matches = True
+        for i in range(1,self.number_of_itteration+1):
+            result = self.logical_comparison_distance(pattern)
+            matched = result[0]
+            not_matched = result[1]
+
+            for node in matched:
+                test_matches &= all(node.dist < child.dist for child in node.children)
+            for node in not_matched:
+                test_child = True
+                for child in node.children:
+                    test_child &= node.dist < child.dist
+                test_matches &= not test_child
+
+        self.assertTrue(test_matches)
+
+    def test_more_than_children(self):
+        pattern = TreePattern(""" '@.dist > [:children:].dist' ; """, quoted_node_names=True)
+        test_matches = True
+        for i in range(1,self.number_of_itteration+1):
+            result = self.logical_comparison_distance(pattern)
+            matched = result[0]
+            not_matched = result[1]
+
+            for node in matched:
+                test_matches &= all(node.dist > child.dist for child in node.children)
+            for node in not_matched:
+                test_child = True
+                for child in node.children:
+                    test_child &= node.dist > child.dist
+                test_matches &= not test_child
+
+        self.assertTrue(test_matches)
+
+    def test_more_than_any_child(self):
+        pattern = TreePattern(""" '@.dist > [:any_child:].dist' ; """, quoted_node_names=True)
+        test_matches = True
+        for i in range(1,self.number_of_itteration+1):
+            result = self.logical_comparison_distance(pattern)
+            matched = result[0]
+            not_matched = result[1]
+
+            for node in matched:
+                test_matches &= any(node.dist > child.dist for child in node.children)
+            for node in not_matched:
+                test_matches &= all(node.dist <= child.dist for child in node.children)
+
+        self.assertTrue(test_matches)
+
+    def test_less_than_any_child(self):
+        pattern =  TreePattern(""" '@.dist < [:any_child:].dist' ; """, quoted_node_names=True)
+        test_matches = True
+        for i in range(1,self.number_of_itteration+1):
+            result = self.logical_comparison_distance(pattern)
+            matched = result[0]
+            not_matched = result[1]
+
+            for node in matched:
+                test_matches &= any(node.dist < child.dist for child in node.children)
+            for node in not_matched:
+                test_matches &= all(node.dist >= child.dist for child in node.children)
+
+        self.assertTrue(test_matches)
+
+
 class test_exrteme_cases(unittest.TestCase):
     def setUp(self):
         if len(sys.argv) > 1 and sys.argv[1]:
@@ -44,8 +159,8 @@ class test_exrteme_cases(unittest.TestCase):
         var_min = min(dists) # The correct mimimum value should be this using python function.
 
         # Define the patterns and run the match.
-        b = TreePattern(""" '@.dist >= [:all_nodes:].dist' ; """, quoted_node_names=True)
-        c = TreePattern(""" '@.dist <= [:all_nodes:].dist' ; """, quoted_node_names=True)
+        b = TreePattern(""" '@.dist > [:all_nodes:].dist' ; """, quoted_node_names=True)
+        c = TreePattern(""" '@.dist < [:all_nodes:].dist' ; """, quoted_node_names=True)
 
         for i in b.find_match(a): tree_max = i.dist
         for i in c.find_match(a): tree_min = i.dist

--- a/test/test_logical_comparison.py
+++ b/test/test_logical_comparison.py
@@ -1,0 +1,83 @@
+import unittest
+import random
+import sys
+
+#assuming ete3 is not installed. they will be imported from local directory on developement modules.
+from ete3 import PhyloTree, Tree, NCBITaxa
+from treematcher import TreePattern
+
+class test_exrteme_cases(unittest.TestCase):
+    def setUp(self):
+        if len(sys.argv) > 1 and sys.argv[1]:
+          self.number_of_itteration = int(sys.argv[1])
+        else:
+          self.number_of_itteration = 1000
+
+        if len(sys.argv) > 2 and sys.argv[2]:
+          self.number_of_leaves = int(sys.argv[2])
+        else:
+          self.number_of_leaves = 30
+
+    def compare_extreme_values(self):
+        # define a tree
+        a = Tree()
+        a.populate(self.number_of_leaves)
+
+        # find the number of nodes
+        length = 0
+        for node in a.traverse():
+            length += 1
+
+        # create a list of defined random distances, so the max can be verified.
+        maximum = 1000.0 # allow a bigger possibility of mistake, by adding a lot of values.
+        dists = []
+        for i in range(0, length):
+            dists += [round(random.uniform(0.1, maximum), 1)]
+
+        # set nodes distances to the nodes
+        cursor = 0
+        for node in a.traverse():
+            node.dist = dists[cursor]
+            cursor += 1
+
+        var_max = max(dists)
+        var_min = min(dists) # The correct mimimum value should be this using python function.
+
+        # Define the patterns and run the match.
+        b = TreePattern(""" '@.dist >= [:all_nodes:].dist' ; """, quoted_node_names=True)
+        c = TreePattern(""" '@.dist <= [:all_nodes:].dist' ; """, quoted_node_names=True)
+
+        for i in b.find_match(a): tree_max = i.dist
+        for i in c.find_match(a): tree_min = i.dist
+
+        # Retrieve again all the values and find the max again for verification.
+        dists_sec = []
+        for node in a.traverse():
+            dists_sec += [node.dist]
+            again_max = max(dists_sec)
+            again_min = min(dists_sec)
+
+        if not sum(dists) == sum(dists_sec):
+            return 2
+
+        # get results
+        if var_max == tree_max == again_max and var_min == tree_min == again_min:
+            return 0
+        else:
+            return 1
+
+    def test_exrteme_cases(self):
+        num = self.compare_extreme_values()
+        correct = 0
+        fails = 0
+
+        for i in range(1, self.number_of_itteration+1):
+            num = self.compare_extreme_values()
+            if num == 0: correct += 1
+            else: fails += 1
+
+        self.assertEqual(correct, self.number_of_itteration)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/treematcher.py
+++ b/treematcher.py
@@ -427,6 +427,11 @@ class TreePattern(Tree):
         if "root" in self.controller and self.controller["root"]: constraints.append("__target_node.is_root()")
         if "leaf" in self.controller and self.controller["leaf"]: constraints.append("__target_node.is_leaf()")
 
+        if SYMBOL["any_child"] in self.name:
+            self.name = " any( " + self.name.split("[")[0] + " " + ("[" + self.name.split("[")[1]).replace(SYMBOL["any_child"], "x") + " for x in __target_node.children)"
+            print self.name
+
+
         if not self.name:
             # empty pattern node should match any target node
             constraints.append('')
@@ -435,10 +440,10 @@ class TreePattern(Tree):
             # converts references to node itself if it's in an expression.
             if len(self.name) == 1: constraints.append('')
             else: constraints.append(self.name.replace('@', '__target_node'))
-
         elif self.controller["allow_indirect_connection"]:
             # pattern nodes that allow indirect connection should match any target node
             constraints.append('')
+
         else:
             # if no references to itself, let's assume we search an exact name
             # match (allows using regular newick string as patterns)

--- a/treematcher.py
+++ b/treematcher.py
@@ -286,6 +286,13 @@ class TreePattern(Tree):
             controller["leaf"] = True
             self.name = self.name.split(SYMBOL["is_leaf"])[0]
 
+        # transform sets to the corresponding code
+        if SYMBOL["any_child"] in self.name:
+            self.name = " any( " + self.name.split("[")[0] + " " + ("[" + self.name.split("[")[1]).replace(SYMBOL["any_child"], "x") + " for x in __target_node.children)"
+        elif SYMBOL["children"] in self.name:
+            self.name = " all( " + self.name.split("[")[0] + " " + ("[" + self.name.split("[")[1]).replace(SYMBOL["children"], "x") + " for x in __target_node.children)"
+
+
         # update controller according to metacharacter connection properties.
         if self.name == SYMBOL["one_or_more"]:
             controller["allow_indirect_connection"] = True
@@ -426,12 +433,6 @@ class TreePattern(Tree):
 
         if "root" in self.controller and self.controller["root"]: constraints.append("__target_node.is_root()")
         if "leaf" in self.controller and self.controller["leaf"]: constraints.append("__target_node.is_leaf()")
-
-        if SYMBOL["any_child"] in self.name:
-            self.name = " any( " + self.name.split("[")[0] + " " + ("[" + self.name.split("[")[1]).replace(SYMBOL["any_child"], "x") + " for x in __target_node.children)"
-        elif SYMBOL["all_children"] in self.name:
-            self.name = " all( " + self.name.split("[")[0] + " " + ("[" + self.name.split("[")[1]).replace(SYMBOL["any_child"], "x") + " for x in __target_node.children)"
-
 
 
         if not self.name:

--- a/treematcher.py
+++ b/treematcher.py
@@ -429,7 +429,9 @@ class TreePattern(Tree):
 
         if SYMBOL["any_child"] in self.name:
             self.name = " any( " + self.name.split("[")[0] + " " + ("[" + self.name.split("[")[1]).replace(SYMBOL["any_child"], "x") + " for x in __target_node.children)"
-            print self.name
+        elif SYMBOL["all_children"] in self.name:
+            self.name = " all( " + self.name.split("[")[0] + " " + ("[" + self.name.split("[")[1]).replace(SYMBOL["any_child"], "x") + " for x in __target_node.children)"
+
 
 
         if not self.name:


### PR DESCRIPTION
Treematcher has now defined sets for nodes comparison.
These sets are
- all children  `[:children:]` 
- any child `[:any_child:]`
- all nodes `[:all_nodes:]` (for finding maximum, minimum etc)

In `[:all_nodes:]`  tests the node that is tested has to be root.

Syntax:
`TreePattern(""" '@.attribute  _logicalOperator_ [:set:].attribute' ; """, quoted_node_names=True)` 
e.g. `TreePattern(""" '@.support > [:children].support'; """, quoted_node_names=True)`

These sets can be combined with numerical values
e.g. `TreePattern(""" '@.dist >= [:any_child:].dist * 3' ; """, quoted_node_names=True)`

