### PR TITLE
Node names as python expressions

### DIFF
--- a/symbols.py
+++ b/symbols.py
@@ -6,7 +6,12 @@ SYMBOL = {
 	'zero_or_more': '*',
 	'one_or_more': '+',
 	'zero_or_one': '?',
+	'defined_number_set': '{'
+}
+
+SET = {
 	'children': '[:children:]',
 	'any_child': '[:any_child:]',
 	'all_nodes': '[:all_nodes:]'
+
 }

--- a/symbols.py
+++ b/symbols.py
@@ -6,7 +6,8 @@ SYMBOL = {
 	'zero_or_more': '*',
 	'one_or_more': '+',
 	'zero_or_one': '?',
-	'defined_number_set': '{'
+	'defined_number_set_start': '{',
+	'defined_number_set_end': '}'
 }
 
 SET = {

--- a/test/test_metacharacters.py
+++ b/test/test_metacharacters.py
@@ -8,6 +8,71 @@ from treematcher import TreePattern
 # plus symbol acts "one_or_more" matches
 # trees from treematcher.py test function, except t6.
 
+class Test_basic_one_or_more_test(unittest.TestCase):
+    def test_one_or_mote_basic(self):
+        '''
+            The + represents one or more nodes.
+        '''
+
+        # should not match any pattern
+        t1 = PhyloTree(""" ((c,g)a) ; """, format=8, quoted_node_names=False)
+
+        # should not match any pattern
+        # does not match pattern 1 because there must be at least one node between a and (c,d)
+        t2 = PhyloTree(""" ((c,d)a) ; """, format=8, quoted_node_names=False)
+
+        # should match patterns 1,2
+        t3 = PhyloTree(""" ((d,c)b)a ; """, format=8, quoted_node_names=False)
+
+        # should match patterns 1,2
+        t4 = PhyloTree(""" ((c,d),(e,f)b)a ; """, format=8, quoted_node_names=False)
+
+        # should match pattern 1,2
+        t5 = PhyloTree(""" (((e,f)dum,(c,d)dee)b)a ; """, format=8, quoted_node_names=False)
+
+        # should match only 1
+        # does not match pattern 2 since (c,g) does not match (c,d)
+        t6 = PhyloTree(""" (((e,f),(c,g)b)b)a ; """, format=8, quoted_node_names=False)
+
+        # should match 1,2,3
+        t7 = PhyloTree(""" (((e,f,g)d,(e,f,i)c)b)a ; """, format=8, quoted_node_names=False)
+
+        # should match 1,2,3
+        t8 = PhyloTree(""" (((e,f,i)d,(e,f,g)c)b)a ; """, format=8, quoted_node_names=False)
+
+        # should match 1,2 not 3
+        t9 = PhyloTree(""" (((e,f,i)d,(e,f,j)c)b)a ; """, format=8, quoted_node_names=False)
+
+        # Should match 1,2,3
+        # does not match pattern4 because ('e','f','g') should come from sibling of b
+        t10 = PhyloTree(""" (b,((g,h,i)b,(e,f,g)c)d)a ; """, format=8, quoted_node_names=False)
+
+        # should match 1,3,4
+        # does not match pattern 2 because (c,c) does not match (c,d)
+        t11 = PhyloTree("""  ( ((e, f, g) c) b, ((g, (w)h, i)c) d) a ; """, format=8, quoted_node_names=False)
+
+        pattern1 = TreePattern(""" ((c)+)a ;""", quoted_node_names=False)
+        pattern2 = TreePattern(""" (('c','d')'+') 'a' ;""", quoted_node_names=True)
+        pattern3 = TreePattern(""" (('e','f','g')'+') 'a' ;""", quoted_node_names=True)
+        pattern4 = TreePattern(""" ((('g','h','i')+)'d',('e','f','g')'+') 'a' ;""", quoted_node_names=True)
+
+        pattern1_match = [3, 4, 5, 6, 7, 8, 9, 10, 11]
+        pattern2_match = [3, 4, 5, 7, 8, 9, 10]
+        pattern3_match = [7, 8, 10, 11]
+        pattern4_match = [11]
+        true_match = [pattern1_match, pattern2_match, pattern3_match, pattern4_match]
+
+        test_flag = True
+
+        for p_num,pattern in enumerate([pattern1, pattern2, pattern3, pattern4]):
+            pattern_match = []
+            for tree_num, tree in enumerate([t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11]):
+                if list(pattern.find_match(tree, maxhits=None)):
+                    pattern_match += [tree_num+1]
+            test_flag &= (pattern_match == true_match[p_num])
+
+        self.assertTrue(test_flag)
+
 class Test_one_or_more_functionality_test(unittest.TestCase):
     def setUp(self):
         self.t1 = PhyloTree(""" ((c,g)a) ; """, format=8, quoted_node_names=False)

--- a/test/test_metacharacters.py
+++ b/test/test_metacharacters.py
@@ -396,5 +396,48 @@ class Test_zero_or_one_symbol(unittest.TestCase):
             matches += [current_matches]
         self.assertEqual(true_matches,  matches)
 
+class Test_node_name_parsing(unittest.TestCase):
+    def setUp(self):
+        self.t1 = PhyloTree(""" ((c,g)a) ; """, format=8, quoted_node_names=False)
+        self.t2 = PhyloTree(""" ((c,d)a) ; """, format=8, quoted_node_names=False)
+        self.t3 = PhyloTree(""" ((d,c)b)a ; """, format=8, quoted_node_names=False)
+        self.t4 = PhyloTree(""" ((c,d),(e,f)b)a ; """, format=8, quoted_node_names=False)
+        self.t5 = PhyloTree(""" (((e,f)dum,(c,d)dee)b)a ; """, format=8, quoted_node_names=False)
+        self.t6 = PhyloTree(""" (((e,f),(c,g)b)b)a ; """, format=8, quoted_node_names=False)
+        self.t7 = PhyloTree(""" (((e,f,g)d,(e,f,i)c)b)a ; """, format=8, quoted_node_names=False)
+        self.t8 = PhyloTree(""" (((e,f,i)d,(e,f,g)c)b)a ; """, format=8, quoted_node_names=False)
+        self.t9 = PhyloTree(""" (((e,f,i)d,(e,f,j)c)b)a ; """, format=8, quoted_node_names=False)
+        self.t10 = PhyloTree(""" (b,((g,h,i)b,(e,f,g)c)d)a ; """, format=8, quoted_node_names=False)
+        self.t11 = PhyloTree("""  ( ((e, f, g) c) b, ((g, h, i)c) d) a ; """, format=8, quoted_node_names=False)
+        self.t12 = PhyloTree("""  ((( ((e, f, g) c) b, (((g, h, i)c)n) d)k)m) a ; """, format=8, quoted_node_names=False)
+        self.t13 = PhyloTree(""" ((d,c)a)a ; """, format=8, quoted_node_names=False)
+
+        self.trees = [self.t1, self.t2, self.t3, self.t4, self.t5, self.t6, self.t7, self.t8, self.t9, self.t10, self.t11, self.t12, self.t13]
+
+
+    def test_multiple_constraints(self):
+        pt1 = TreePattern(""" ('c, @.dist == 1')'a, @.dist == 1' ; """, quoted_node_names=True)
+        pt2 = TreePattern(""" ('c, @.dist == 1')'a, @.dist == 0' ; """, quoted_node_names=True)
+        pt3 = TreePattern(""" ('c, @.dist == 1')'a' ; """, quoted_node_names=True)
+        pt4 = TreePattern(""" (('c, @.dist == 1')'+')'a, @.dist == 0' ; """, quoted_node_names=True)
+
+        pt1_match = [1, 2, 13]
+        pt2_match = []
+        pt3_match = [1, 2, 13]
+        pt4_match = [3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]
+
+        patterns = [pt1, pt2, pt3, pt4]
+        true_matches = [pt1_match, pt2_match, pt3_match, pt4_match]
+
+        matches = []
+        for num, pattern in enumerate(patterns):
+            current_matches = []
+            for t_num, tree in enumerate(self.trees):
+                if list(pattern.find_match(tree, maxhits=None)):
+                    current_matches += [t_num + 1]
+            matches += [current_matches]
+
+        self.assertTrue(true_matches == matches)
+
 if __name__ == '__main__':
     unittest.main()

--- a/treematcher.py
+++ b/treematcher.py
@@ -370,8 +370,8 @@ class TreePattern(Tree):
             controller["direct_connection_first"] = True
             controller["allow_indirect_connection"] = True
             controller["high"] = 1
-        elif SYMBOL["defined_number_set"] in self.name:
-            split = self.name.split(SYMBOL["defined_number_set"])
+        elif SYMBOL["defined_number_set_start"] in self.name:
+            split = self.name.split(SYMBOL["defined_number_set_start"])
             self.name = split[0]
             bounds = self.decode_repeat_symbol(split[1])
             controller["low"] = bounds[0]

--- a/treematcher.py
+++ b/treematcher.py
@@ -600,64 +600,7 @@ class TreePattern(Tree):
 
 
 def test():
-    '''
-        The + represents one or more nodes.
-    '''
-
-    # should not match any pattern
-    t1 = PhyloTree(""" ((c,g)a) ; """, format=8, quoted_node_names=False)
-
-    # should not match any pattern
-    # does not match pattern 1 because there must be at least one node between a and (c,d)
-    t2 = PhyloTree(""" ((c,d)a) ; """, format=8, quoted_node_names=False)
-
-    # should match patterns 1,2
-    t3 = PhyloTree(""" ((d,c)b)a ; """, format=8, quoted_node_names=False)
-
-    # should match patterns 1,2
-    t4 = PhyloTree(""" ((c,d),(e,f)b)a ; """, format=8, quoted_node_names=False)
-
-    # should match pattern 1,2
-    t5 = PhyloTree(""" (((e,f)dum,(c,d)dee)b)a ; """, format=8, quoted_node_names=False)
-
-    # should match only 1
-    # does not match pattern 2 since (c,g) does not match (c,d)
-    t6 = PhyloTree(""" (((e,f),(c,g)b)b)a ; """, format=8, quoted_node_names=False)
-
-    # should match 1,2,3
-    t7 = PhyloTree(""" (((e,f,g)d,(e,f,i)c)b)a ; """, format=8, quoted_node_names=False)
-
-    # should match 1,2,3
-    t8 = PhyloTree(""" (((e,f,i)d,(e,f,g)c)b)a ; """, format=8, quoted_node_names=False)
-
-    # should match 1,2 not 3
-    t9 = PhyloTree(""" (((e,f,i)d,(e,f,j)c)b)a ; """, format=8, quoted_node_names=False)
-
-    # Should match 1,2,3
-    # does not match pattern4 because ('e','f','g') should come from sibling of b
-    t10 = PhyloTree(""" (b,((g,h,i)b,(e,f,g)c)d)a ; """, format=8, quoted_node_names=False)
-
-    # should match 1,3,4
-    # does not match pattern 2 because (c,c) does not match (c,d)
-    t11 = PhyloTree("""  ( ((e, f, g) c) b, ((g, (w)h, i)c) d) a ; """, format=8, quoted_node_names=False)
-
-    pattern1 = TreePattern(""" ((c)+)a ;""", quoted_node_names=False)
-    pattern2 = TreePattern(""" (('c','d')'+') 'a' ;""", quoted_node_names=True)
-    pattern3 = TreePattern(""" (('e','f','g')'+') 'a' ;""", quoted_node_names=True)
-    pattern4 = TreePattern(""" ((('g','h','i')+)'d',('e','f','g')'+') 'a' ;""", quoted_node_names=True)
-
-    pattern1_match = [3, 4, 5, 6, 7, 8, 9, 10, 11]
-    pattern2_match = [3, 4, 5, 7, 8, 9, 10]
-    pattern3_match = [7, 8, 10, 11]
-    pattern4_match = [11]
-    true_match = [pattern1_match, pattern2_match, pattern3_match, pattern4_match]
-
-    for p_num,pattern in enumerate([pattern1, pattern2, pattern3, pattern4]):
-        pattern_match = []
-        for tree_num, tree in enumerate([t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11]):
-            if list(pattern.find_match(tree, maxhits=None)):
-                pattern_match += [tree_num+1]
-        print(pattern_match == true_match[p_num])
+    print "compiled. run /test/test_metacharacters.py and /test/test_logical_comparison.py to test."
 
 
 if __name__ == '__main__':

--- a/treematcher.py
+++ b/treematcher.py
@@ -7,7 +7,7 @@ import ast
 import six
 import copy
 from ete3 import PhyloTree, Tree, NCBITaxa
-from symbols import SYMBOL
+from symbols import SYMBOL, SET
 
 # internal modules
 #...
@@ -279,7 +279,7 @@ class TreePattern(Tree):
             constraint_scope.update({"__target_node": node})
             constraint_scope.update({"__correct_node": correct_node})
             constraint = constraint.replace("@", "__target_node")
-            constraint = constraint.replace(SYMBOL["all_nodes"], "__correct_node")
+            constraint = constraint.replace(SET["all_nodes"], "__correct_node")
 
             try:
                 st = eval(constraint, constraint_scope)
@@ -350,11 +350,11 @@ class TreePattern(Tree):
             self.name = self.name.split(SYMBOL["is_leaf"])[0]
 
         # transform sets to the corresponding code
-        if SYMBOL["any_child"] in self.name:
-            self.name = " any( " + self.name.split("[")[0] + " " + ("[" + self.name.split("[")[1]).replace(SYMBOL["any_child"], "x") + " for x in __target_node.children)"
-        if SYMBOL["children"] in self.name:
-            self.name = " all( " + self.name.split("[")[0] + " " + ("[" + self.name.split("[")[1]).replace(SYMBOL["children"], "x") + " for x in __target_node.children)"
-        if SYMBOL["all_nodes"] in self.name:
+        if SET["any_child"] in self.name:
+            self.name = " any( " + self.name.split("[")[0] + " " + ("[" + self.name.split("[")[1]).replace(SET["any_child"], "x") + " for x in __target_node.children)"
+        if SET["children"] in self.name:
+            self.name = " all( " + self.name.split("[")[0] + " " + ("[" + self.name.split("[")[1]).replace(SET["children"], "x") + " for x in __target_node.children)"
+        if SET["all_nodes"] in self.name:
             controller["single_match"] = True
             controller["single_match_contstraint"] = self.name
             self.name = '@'
@@ -370,8 +370,8 @@ class TreePattern(Tree):
             controller["direct_connection_first"] = True
             controller["allow_indirect_connection"] = True
             controller["high"] = 1
-        elif '{' in self.name:
-            split = self.name.split('{')
+        elif SYMBOL["defined_number_set"] in self.name:
+            split = self.name.split(SYMBOL["defined_number_set"])
             self.name = split[0]
             bounds = self.decode_repeat_symbol(split[1])
             controller["low"] = bounds[0]


### PR DESCRIPTION
Every node name from now on is a python expression or '@' for any node.

Node names can have many properties using commas, a comma represents a python `and`.

quantifier metacharacters can have additional properties e.g. `""" ( ('node') '@.dist > 0.3, @.name == "lala"+')'node' """`.

Metacharacters have to be written last.